### PR TITLE
Add optional argument: -d

### DIFF
--- a/AWSBucketDump.py
+++ b/AWSBucketDump.py
@@ -30,7 +30,8 @@ def print_banner():
 
 def main():
         parser = ArgumentParser()
-        parser.add_argument("-D", dest="download", required=False, action="store_true", default=False, help="Download files. This requires significant diskspace")
+        parser.add_argument("-D", dest="download", required=False, action="store_true", default=False, help="Download files. This requires significant diskspace") 
+        parser.add_argument("-d", dest="savedir", required=False, default=False, help="if -D, then -d 1 to create save directories for each bucket with results.")
         parser.add_argument("-l", dest="hostlist", required=True, help="") 
         parser.add_argument("-g", dest="grepwords", required=False, help="Provide a wordlist to grep for")
         parser.add_argument("-m", dest="maxsize", required=False, help="Maximum file size to download.")
@@ -84,9 +85,14 @@ def main():
         responseFile.close()
         masterList.close()
         cleanUp()
-        if arguments.download == True:
+        if arguments.download and arguments.savedir:
+                print("Downloads enabled (-D), and save directories (-d) for each host will be created/used")
+                downloadFiles(arguments.maxsize, arguments.savedir)
+        elif arguments.download and not arguments.savedir:
+                print("Downloads enabled (-D), and will be saved to current directory")
                 downloadFiles(arguments.maxsize)
-                        
+        else:
+                print("Downloads were not enabled (-D), not saving results locally.")
 
 def cleanUp():
         print("Cleaning Up Files")
@@ -99,7 +105,7 @@ def cleanUp():
         os.remove("interestingFiles.txt")
         os.remove("responseFile.txt")
         
-def downloadFiles(maxsize):
+def downloadFiles(maxsize, mkdir = False):
         MAX_SIZE = int(maxsize)
         print(MAX_SIZE)
         print("Beginning File Download, this may take some time..")
@@ -114,6 +120,20 @@ def downloadFiles(maxsize):
                                 if local_filename =="":
                                         print("Directory..\n")
                                 else:
+                                        if mkdir:
+                                                local_savedir = (line.split('/')[-2]).rstrip()
+                                                # assign new path + filename for result for use in save below
+                                                local_filename = "".join("./%s/%s") % (local_savedir, local_filename)
+                                                # check if dir for host exists, if not create it
+                                                if not os.path.exists("./%s" % local_savedir):
+                                                        print("Creating directory for host: (%s)" % local_savedir)
+                                                        os.mkdir(local_savedir)
+                                                else:
+                                                        print("Using existing directory for host: (%s)" % local_savedir)
+
+                                                print("Saving file to: %s") % local_filename
+
+
                                         r = requests.get(line.rstrip(), stream=True)
                                         if int(r.headers['Content-Length']) > MAX_SIZE:
                                                 print("This file is greater than the specified max size.. skipping..\n")
@@ -139,18 +159,19 @@ def status200(response,grepList,line):
                         Keys.append(child['Key'])
         except:
                pass
+        # make greplist optional, save everything if not supplied
         for lines in grepList:
-                lines = (str(lines)).rstrip()
-                for words in Keys:
-                        words = (str(words)).rstrip()
-                        if lines in words:
-                                s = requests.get("http://"+line.rstrip()+".s3.amazonaws.com/"+words)
-                                if s.status_code != 200:
-                                        print("")
-                                else:
-                                        interest.append("http://"+line.rstrip()+".s3.amazonaws.com/"+words+"\n")
-                                s.close()
-        return(interest)
+            lines = (str(lines)).rstrip()
+            for words in Keys:
+                words = (str(words)).rstrip()
+                if lines in words:
+                    s = requests.get("http://"+line.rstrip()+".s3.amazonaws.com/"+words)
+                if s.status_code != 200:
+                    print("Received %s on %s" % (s.status_code, words))
+                else:
+                    interest.append("http://"+line.rstrip()+".s3.amazonaws.com/"+words+"\n")
+                 s.close()
 
+        return(interest)
 if __name__ == "__main__":
     main()                  

--- a/AWSBucketDump.py
+++ b/AWSBucketDump.py
@@ -131,7 +131,7 @@ def downloadFiles(maxsize, mkdir = False):
                                                 else:
                                                         print("Using existing directory for host: (%s)" % local_savedir)
 
-                                                print("Saving file to: %s") % local_filename
+                                                print("Saving file to: %s" % local_filename)
 
 
                                         r = requests.get(line.rstrip(), stream=True)

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ After building this tool, I did find an interesting article from Rapid7 regardin
 `optional arguments:`
 `  -h, --help    show this help message and exit`
 `  -D            Download files. This requires significant diskspace`
+`  -d            If set to 1 or True, create directories for each host w/ results`
  ` -l HOSTLIST`
  ` -g GREPWORDS  Provide a wordlist to grep for`
   `-m MAXSIZE    Maximum file size to download.`
   
  `python AWSBucketDump.py -l BucketNames.txt -g interesting_Keywords.txt -D -m 500000`
-  


### PR DESCRIPTION
ex: python AWSBucketDump.py -l BucketNames.txt -g interesting_Keywords.txt -D -m 500000 -d 1

When -D is set, and -d is set to True or 1, create a directory for the given bucket hostname in which to save the files found in it.  If the directory already exists, use that existing directory.

This allows for a bit more sanity in storage locally when searching large numbers of buckets. :-)